### PR TITLE
Integrando API Via CEP

### DIFF
--- a/grails-app/assets/javascripts/viaCep.js
+++ b/grails-app/assets/javascripts/viaCep.js
@@ -1,31 +1,29 @@
 function cepSearch(valor) {
     let cep = valor.replace(/\D/g, '');
-    if (cep !== "") {
-        let validateCep = /^[0-9]{8}$/;
-        if(validateCep.test(cep)) {
-            waitingFormFields();
-            fetchCepData(cep);
-        } else {
-            cleanAddressFields();
-            alert("Formato de CEP inválido.");
-        }
-    } else {
+    if (cep === "") {
         cleanAddressFields();
+        return;
     }
+    let validateCep = /^[0-9]{8}$/;
+    if (!validateCep.test(cep)) {
+        cleanAddressFields();
+        alert("Formato de CEP inválido.");
+        return;
+    }
+    waitingFormFields();
+    fetchCepData(cep);
 }
-
 function viaCepReceiver(json) {
-    if (!("erro" in json)) {
-        document.getElementById('address').value=(json.logradouro);
-        document.getElementById('district').value=(json.bairro);
-        document.getElementById('city').value=(json.localidade);
-        document.getElementById('state').value=(json.uf);
-    } else {
+    if ("erro" in json) {
         cleanAddressFields();
         alert("CEP inválido");
+        return;
     }
+    document.getElementById('address').value=(json.logradouro);
+    document.getElementById('district').value=(json.bairro);
+    document.getElementById('city').value=(json.localidade);
+    document.getElementById('state').value=(json.uf);
 }
-
 function fetchCepData(cep) {
     let script = document.createElement('script');
     script.src = 'https://viacep.com.br/ws/'+ cep + '/json/?callback=viaCepReceiver';

--- a/grails-app/assets/javascripts/viaCep.js
+++ b/grails-app/assets/javascripts/viaCep.js
@@ -1,0 +1,47 @@
+function cepSearch(valor) {
+    let cep = valor.replace(/\D/g, '');
+    if (cep !== "") {
+        let validateCep = /^[0-9]{8}$/;
+        if(validateCep.test(cep)) {
+            waitingFormFields();
+            fetchCepData(cep);
+        } else {
+            cleanAddressFields();
+            alert("Formato de CEP inválido.");
+        }
+    } else {
+        cleanAddressFields();
+    }
+}
+
+function viaCepReceiver(json) {
+    if (!("erro" in json)) {
+        document.getElementById('address').value=(json.logradouro);
+        document.getElementById('district').value=(json.bairro);
+        document.getElementById('city').value=(json.localidade);
+        document.getElementById('state').value=(json.uf);
+    } else {
+        cleanAddressFields();
+        alert("CEP inválido");
+    }
+}
+
+function fetchCepData(cep) {
+    let script = document.createElement('script');
+    script.src = 'https://viacep.com.br/ws/'+ cep + '/json/?callback=viaCepReceiver';
+    document.body.appendChild(script);
+}
+
+function cleanAddressFields() {
+    document.getElementById('address').value=("");
+    document.getElementById('district').value=("");
+    document.getElementById('city').value=("");
+    document.getElementById('state').value=("");
+}
+
+function waitingFormFields() {
+    document.getElementById('address').value="...";
+    document.getElementById('district').value="...";
+    document.getElementById('city').value="...";
+    document.getElementById('state').value="...";
+}

--- a/grails-app/views/payer/create.gsp
+++ b/grails-app/views/payer/create.gsp
@@ -3,6 +3,7 @@
         <meta name="layout" content="main" >
         <title>Registrar Novo Pagador</title>
         <asset:javascript src="changePersonType.js"/>
+        <asset:javascript src="viaCep.js"/>
     </head>
     <body>
         <h1>Registro de Novo Pagador</h1>
@@ -31,7 +32,7 @@
 
             <div>
                 <label for="cep">CEP:</label>
-                <input type="text" name="cep" placeholder="12345-678" maxLength=9 id="cep"/>
+                <input type="text" name="cep" placeholder="12345-678" maxLength=9 id="cep" onblur="cepSearch(this.value)"/>
             </div>
 
             <div>

--- a/grails-app/views/payer/edit.gsp
+++ b/grails-app/views/payer/edit.gsp
@@ -4,6 +4,7 @@
         <meta name="layout" content="main" >
         <title>Editar Pagador</title>
         <asset:javascript src="changePersonType.js"/>
+        <asset:javascript src="viaCep.js"/>
     </head>
     <body>
         <h1>Atualizar registro de Pagador</h1>
@@ -32,7 +33,7 @@
 
             <div>
                 <label for="cep">CEP:</label>
-                <input type="text" name="cep" value="${payer.cep}" placeholder="12345-678" maxLength=9 id="cep"/>
+                <input type="text" name="cep" value="${payer.cep}" placeholder="12345-678" maxLength=9 id="cep" onblur="cepSearch(this.value)"/>
             </div>
 
             <div>


### PR DESCRIPTION
Mostrando a integração da API Via CEP no formulário de payer. Preenchendo o campo de CEP com um CEP válido os campos de estado, cidade, bairro e endereço são preenchidos automaticamente, caso seja inserido um CEP inválido ou um formato inválido de CEP aparecerá um aviso na tela.

![integracaoapiviacep](https://github.com/AlexandraPassos/CoinCollector/assets/130087515/40f9b449-a1d4-4a2f-9d9c-f54142b58330)

