### PR TITLE
Adicionando restauração para pagador deletado

### DIFF
--- a/grails-app/controllers/com/coinCollector/PayerController.groovy
+++ b/grails-app/controllers/com/coinCollector/PayerController.groovy
@@ -7,9 +7,20 @@ class PayerController {
     def payerService
 
     def index() {
-        Boolean mustShowDeletedPayers = params.boolean("mustShowDeletedPayers") ?: false
-        List<Payer> payerList = Payer.query([customerId: 1, deleted: mustShowDeletedPayers]).list()
-        return [payerList: payerList, mustShowDeletedPayers: mustShowDeletedPayers]
+        Map allowedParams = [
+            customerId: 1,
+            deletedOnly: false,
+            includeDeleted: false
+        ]
+
+        if (params.payerListFilter == "INACTIVE") {
+            allowedParams.deletedOnly = true
+        } else if (params.payerListFilter == "ACTIVE") {
+            allowedParams.includeDeleted = true
+        }
+
+        List<Payer> payerList = Payer.query(allowedParams).list()
+        return [payerList: payerList]
     }
 
     def show(Long id) {

--- a/grails-app/controllers/com/coinCollector/PayerController.groovy
+++ b/grails-app/controllers/com/coinCollector/PayerController.groovy
@@ -7,8 +7,10 @@ class PayerController {
     def payerService
 
     def index() {
-        return [payerList : Payer.query([customerId: 1]).list()]
-    }  
+        Boolean mustShowDeletedPayers = params.boolean("mustShowDeletedPayers") ?: false
+        List<Payer> payerList = Payer.query([customerId: 1, deleted: mustShowDeletedPayers]).list()
+        return [payerList: payerList, mustShowDeletedPayers: mustShowDeletedPayers]
+    }
 
     def show(Long id) {
         if (!id) {
@@ -75,6 +77,18 @@ class PayerController {
             Long id = params.long("id")
             payerService.delete(id)
             flash.message = "Pagador deletado com sucesso"
+            redirect(action: 'index')
+        } catch (Exception exception) {
+            flash.message = exception.message
+            redirect(action: 'index')
+        }
+    }
+
+    def restore() {
+        try {
+            Long id = params.long("id")
+            payerService.restore(id)
+            flash.message = "Pagador inativo restaurado com sucesso"
             redirect(action: 'index')
         } catch (Exception exception) {
             flash.message = exception.message

--- a/grails-app/controllers/com/coinCollector/PayerController.groovy
+++ b/grails-app/controllers/com/coinCollector/PayerController.groovy
@@ -7,19 +7,13 @@ class PayerController {
     def payerService
 
     def index() {
-        Map allowedParams = [
-            customerId: 1,
-            deletedOnly: false,
-            includeDeleted: false
-        ]
+        params.customerId = 1
 
-        if (params.payerListFilter == "INACTIVE") {
-            allowedParams.deletedOnly = true
-        } else if (params.payerListFilter == "ACTIVE") {
-            allowedParams.includeDeleted = true
+        if (params.deletedOnly && !Boolean.valueOf(params.deletedOnly)) {
+            params.includeDeleted = true
         }
 
-        List<Payer> payerList = Payer.query(allowedParams).list()
+        List<Payer> payerList = Payer.query(params).list()
         return [payerList: payerList]
     }
 

--- a/grails-app/domain/com/coinCollector/Payer.groovy
+++ b/grails-app/domain/com/coinCollector/Payer.groovy
@@ -9,8 +9,8 @@ class Payer extends BasePerson {
         query { Map search ->
             if (search.containsKey("id")) eq("id", Long.valueOf(search.id))
 
-            if (!search.containsKey("includeDeleted")) eq("deleted", false)
-            
+            if (search.containsKey("deleted")) eq("deleted", search.deleted)
+
             if (search.containsKey("customerId")) eq("customer.id", Long.valueOf(search.customerId))
         }
     }

--- a/grails-app/domain/com/coinCollector/Payer.groovy
+++ b/grails-app/domain/com/coinCollector/Payer.groovy
@@ -7,11 +7,15 @@ class Payer extends BasePerson {
 
     static namedQueries = {
         query { Map search ->
-            if (search.containsKey("id")) eq("id", Long.valueOf(search.id))
+            if (search.containsKey("id")) eq("id", Long.valueOf(search.id as String))
 
-            if (search.containsKey("deleted")) eq("deleted", search.deleted)
+            if (search.containsKey("deletedOnly") && search.deletedOnly) {
+                eq("deleted", search.deletedOnly)
+            } else if (search.containsKey("includeDeleted") && search.includeDeleted) {
+                eq("deleted", !search.includeDeleted)
+            }
 
-            if (search.containsKey("customerId")) eq("customer.id", Long.valueOf(search.customerId))
+            if (search.containsKey("customerId")) eq("customer.id", Long.valueOf(search.customerId as String))
         }
     }
 }

--- a/grails-app/domain/com/coinCollector/Payer.groovy
+++ b/grails-app/domain/com/coinCollector/Payer.groovy
@@ -9,10 +9,10 @@ class Payer extends BasePerson {
         query { Map search ->
             if (search.containsKey("id")) eq("id", Long.valueOf(search.id as String))
 
-            if (search.containsKey("deletedOnly") && search.deletedOnly) {
-                eq("deleted", search.deletedOnly)
-            } else if (search.containsKey("includeDeleted") && search.includeDeleted) {
-                eq("deleted", !search.includeDeleted)
+            if (Boolean.valueOf(search.deletedOnly)) {
+                eq("deleted", true)
+            } else if (!Boolean.valueOf(search.includeDeleted)) {
+                eq("deleted", false)
             }
 
             if (search.containsKey("customerId")) eq("customer.id", Long.valueOf(search.customerId as String))

--- a/grails-app/services/com/coinCollector/PayerService.groovy
+++ b/grails-app/services/com/coinCollector/PayerService.groovy
@@ -10,8 +10,8 @@ import utils.phoneNumber.PhoneNumberUtils
 
 @Transactional
 class PayerService {
-    public void save(Map params) {
 
+    public void save(Map params) {
         if(PersonType.convert(params.personType) == PersonType.PF && !CpfCnpjUtils.cpfIsValid(params.cpfCnpj)) return
         if(PersonType.convert(params.personType) == PersonType.PJ && !CpfCnpjUtils.cnpjIsValid(params.cpfCnpj)) return 
         if(!PhoneNumberUtils.phoneNumberIsValid(params.phoneNumber)) return
@@ -43,15 +43,15 @@ class PayerService {
         payer.name = params.name
         payer.email = params.email
         payer.personType = params.personType
-        payer.cpfCnpj = params.cpfCnpj
-        payer.cep = params.cep
+        payer.cpfCnpj = FormattingParameters.removeSpecialCharacters(params.cpfCnpj)
+        payer.cep = FormattingParameters.removeSpecialCharacters(params.cep)
         payer.state = params.state
         payer.city = params.city
         payer.district = params.district
         payer.address = params.address
-        payer.addressNumber = params.addressNumber
+        payer.addressNumber = FormattingParameters.removeSpecialCharacters(params.addressNumber)
         payer.complement = params.complement
-        payer.phoneNumber = params.phoneNumber
+        payer.phoneNumber = FormattingParameters.removeSpecialCharacters(params.phoneNumber)
         payer.save(failOnError: true)
     }
   
@@ -61,5 +61,13 @@ class PayerService {
         if (!payer) throw new Exception("Pagador com o ID ${id} não encontrado.")
         payer.deleted = true
         payer.save(failOnError: true) 
+    }
+
+    public void restore(Long id) {
+        if (!id) throw new Exception("ID do pagador não informado")
+        Payer payer = Payer.query([id: id]).get()
+        if (!payer) throw new Exception("Pagador com o ID ${id} não encontrado.")
+        payer.deleted = false
+        payer.save(failOnError: true)
     }
 }

--- a/grails-app/views/payer/index.gsp
+++ b/grails-app/views/payer/index.gsp
@@ -1,33 +1,49 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta name="layout" content="main" >
+        <meta name="layout" content="main">
         <title>Listagem de pagadores</title>
     </head>
+
     <body>
         <g:link action="create">
             <button>Novo pagador</button>
         </g:link>
-        <h1>Lista com pagadores</h1>
-            <table>
+        <g:if test="${!mustShowDeletedPayers}">
+            <h1>Lista de Pagadores Ativos</h1>
+        </g:if>
+        <g:else>
+            <h1>Lista de Pagadores Inativos</h1>
+        </g:else>
+        <table>
+            <tr>
+                <th>ID</th>
+                <th>Nome</th>
+                <th>E-mail</th>
+                <th>CPF/CNPJ</th>
+                <th>Celular</th>
+                <th>Mais informações</th>
+            </tr>
+            <g:each in="${payerList}" var="payer">
                 <tr>
-                    <th>ID</th>
-                    <th>Nome</th>
-                    <th>E-mail</th>
-                    <th>CPF/CNPJ</th>
-                    <th>Celular</th>
-                    <th>Mais informações</th>
+                    <td>${payer?.id}</td>
+                    <td>${payer?.name}</td>
+                    <td>${payer?.email}</td>
+                    <td>${payer?.cpfCnpj}</td>
+                    <td>${payer?.phoneNumber}</td>
+                    <td><g:link action="show" id="${payer?.id}">Visualizar mais</g:link></td>
                 </tr>
-                <g:each in="${payerList}" var="payer">
-                    <tr>
-                        <td>${payer?.id}</td>
-                        <td>${payer?.name}</td>
-                        <td>${payer?.email}</td>
-                        <td>${payer?.cpfCnpj}</td>
-                        <td>${payer?.phoneNumber}</td>
-                        <td><g:link action="show" id="${payer?.id}">Visualizar mais</g:link></td>
-                    </tr>
-                </g:each>
-            </table>
+            </g:each>
+        </table>
+        <g:if test="${!mustShowDeletedPayers}">
+            <button>
+                <a href="${createLink(controller: "payer", action: "index", params: [mustShowDeletedPayers: true])}">Mostrar pagadores inativos</a>
+            </button>
+        </g:if>
+        <g:else>
+            <button>
+                <a href="${createLink(controller: "payer", action: "index", params: [mustShowDeletedPayers: false])}">Voltar</a>
+            </button>
+        </g:else>
     </body>
 </html>

--- a/grails-app/views/payer/index.gsp
+++ b/grails-app/views/payer/index.gsp
@@ -6,12 +6,24 @@
     </head>
     <body>
         <a href="${ createLink(controller: "payer", action: "create", params: [params]) }" class="btn btn-default">Novo pagador</a>
-        <g:if test="${!mustShowDeletedPayers}">
-            <a href="${createLink(controller: "payer", action: "index", params: [mustShowDeletedPayers: true])}">Mostrar pagadores inativos</a>
-        </g:if>
-        <g:else>
-            <a href="${createLink(controller: "payer", action: "index", params: [mustShowDeletedPayers: false])}">Mostrar pagadores ativos</a>
-        </g:else>
+
+        <g:form>
+            <label for="payerListFilter">Filtrar:</label>
+            <g:select
+                    name="payerListFilter"
+                    class="marg-5"
+                    data-constraint="select"
+                    from="${[
+                            [value: "ACTIVE", label: "Exibir pagadores ativos"],
+                            [value: "INACTIVE", label: "Exibir pagadores inativos"],
+                            [value: "ALL", label: "Exibir todos os pagadores"]
+                    ]}"
+                    optionKey="value"
+                    optionValue="label"
+                    value="${params.payerListFilter}"/>
+            <input type="submit" value="Aplicar"/>
+        </g:form>
+
         <h1>Lista de Pagadores</h1>
         <table>
             <tr>
@@ -30,12 +42,13 @@
                     <td>${payer?.cpfCnpj}</td>
                     <td>${payer?.phoneNumber}</td>
                     <td>
-                        <g:if test="${mustShowDeletedPayers}">
+                        <g:if test="${payer.deleted}">
                             Inativo
                         </g:if>
                         <g:else>
                             Ativo
                         </g:else>
+                    </td>
                 </tr>
             </g:each>
         </table>

--- a/grails-app/views/payer/index.gsp
+++ b/grails-app/views/payer/index.gsp
@@ -4,17 +4,15 @@
         <meta name="layout" content="main">
         <title>Listagem de pagadores</title>
     </head>
-
     <body>
-        <g:link action="create">
-            <button>Novo pagador</button>
-        </g:link>
+        <a href="${ createLink(controller: "payer", action: "create", params: [params]) }" class="btn btn-default">Novo pagador</a>
         <g:if test="${!mustShowDeletedPayers}">
-            <h1>Lista de Pagadores Ativos</h1>
+            <a href="${createLink(controller: "payer", action: "index", params: [mustShowDeletedPayers: true])}">Mostrar pagadores inativos</a>
         </g:if>
         <g:else>
-            <h1>Lista de Pagadores Inativos</h1>
+            <a href="${createLink(controller: "payer", action: "index", params: [mustShowDeletedPayers: false])}">Mostrar pagadores ativos</a>
         </g:else>
+        <h1>Lista de Pagadores</h1>
         <table>
             <tr>
                 <th>ID</th>
@@ -22,28 +20,24 @@
                 <th>E-mail</th>
                 <th>CPF/CNPJ</th>
                 <th>Celular</th>
-                <th>Mais informações</th>
+                <th>Status</th>
             </tr>
             <g:each in="${payerList}" var="payer">
                 <tr>
                     <td>${payer?.id}</td>
-                    <td>${payer?.name}</td>
+                    <td><a href="${createLink(controller: 'payer', action: 'show', params: [id: payer?.id])}">${payer?.name}</a></td>
                     <td>${payer?.email}</td>
                     <td>${payer?.cpfCnpj}</td>
                     <td>${payer?.phoneNumber}</td>
-                    <td><g:link action="show" id="${payer?.id}">Visualizar mais</g:link></td>
+                    <td>
+                        <g:if test="${mustShowDeletedPayers}">
+                            Inativo
+                        </g:if>
+                        <g:else>
+                            Ativo
+                        </g:else>
                 </tr>
             </g:each>
         </table>
-        <g:if test="${!mustShowDeletedPayers}">
-            <button>
-                <a href="${createLink(controller: "payer", action: "index", params: [mustShowDeletedPayers: true])}">Mostrar pagadores inativos</a>
-            </button>
-        </g:if>
-        <g:else>
-            <button>
-                <a href="${createLink(controller: "payer", action: "index", params: [mustShowDeletedPayers: false])}">Voltar</a>
-            </button>
-        </g:else>
     </body>
 </html>

--- a/grails-app/views/payer/index.gsp
+++ b/grails-app/views/payer/index.gsp
@@ -6,22 +6,21 @@
     </head>
     <body>
         <a href="${ createLink(controller: "payer", action: "create", params: [params]) }" class="btn btn-default">Novo pagador</a>
-
-        <g:form>
-            <label for="payerListFilter">Filtrar:</label>
+        <g:form action = "index">
+            <label for="deletedOnly">Filtrar:</label>
             <g:select
-                    name="payerListFilter"
+                    name="deletedOnly"
                     class="marg-5"
                     data-constraint="select"
                     from="${[
-                            [value: "ACTIVE", label: "Exibir pagadores ativos"],
-                            [value: "INACTIVE", label: "Exibir pagadores inativos"],
-                            [value: "ALL", label: "Exibir todos os pagadores"]
+                            [value: "", label: "Exibir somente pagadores ativos"],
+                            [value: "true", label: "Exibir somente pagadores inativos"],
+                            [value: "false", label: "Exibir todos os pagadores"]
                     ]}"
                     optionKey="value"
                     optionValue="label"
-                    value="${params.payerListFilter}"/>
-            <input type="submit" value="Aplicar"/>
+                    value="${params.deletedOnly}"/>
+            <input type="submit" value="Aplicar" />
         </g:form>
 
         <h1>Lista de Pagadores</h1>

--- a/grails-app/views/payer/index.gsp
+++ b/grails-app/views/payer/index.gsp
@@ -32,7 +32,7 @@
                 <th>E-mail</th>
                 <th>CPF/CNPJ</th>
                 <th>Celular</th>
-                <th>Status</th>
+                <th>Situação</th>
             </tr>
             <g:each in="${payerList}" var="payer">
                 <tr>

--- a/grails-app/views/payer/show.gsp
+++ b/grails-app/views/payer/show.gsp
@@ -1,65 +1,86 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <meta name="layout" content="main" />
+        <meta name="layout" content="main"/>
         <title>Registro de Pagador</title>
     </head>
+
     <body>
         <div id="content" role="main">
             <div class="container">
                 <section class="row">
                     <div id="show-payer" class="col-12 content scaffold-show" role="main">
                         <h1>Registro de Pagador</h1>
+
                         <div class="data-field">
                             <label>Nome:</label>
                             <span>${payer.name}</span>
                         </div>
+
                         <div class="data-field">
                             <label>E-mail:</label>
                             <span>${payer.email}</span>
                         </div>
+
                         <div class="data-field">
                             <label>Tipo de pagador:</label>
                             <span>${payer.personType}</span>
                         </div>
+
                         <div class="data-field">
                             <label>CPF/CNPJ:</label>
                             <span>${payer.cpfCnpj}</span>
                         </div>
+
                         <div class="data-field">
                             <label>CEP:</label>
                             <span>${payer.cep}</span>
                         </div>
+
                         <div class="data-field">
                             <label>Estado:</label>
                             <span>${payer.state}</span>
                         </div>
+
                         <div class="data-field">
                             <label>Cidade:</label>
                             <span>${payer.city}</span>
                         </div>
+
                         <div class="data-field">
                             <label>Bairro:</label>
                             <span>${payer.district}</span>
                         </div>
+
                         <div class="data-field">
                             <label>Endereço:</label>
                             <span>${payer.address}</span>
                         </div>
+
                         <div class="data-field">
                             <label>Número do endereço:</label>
                             <span>${payer.addressNumber}</span>
                         </div>
+
                         <div class="data-field">
                             <label>Complemento:</label>
                             <span>${payer.complement}</span>
                         </div>
+
                         <div class="data-field">
                             <label>Celular:</label>
                             <span>${payer.phoneNumber}</span>
                         </div>
-                        <a href="${ createLink(controller: "payer", action: "edit", params: [id: payer.id]) }" class="btn btn-default">Editar Pagador</a>
-                        <a href="${ createLink(controller: "payer", action: "delete", params: [id: payer.id]) }" class="btn btn-default">Deletar Pagador</a>
+                        <g:if test="${payer.deleted}">
+                            <a href="${createLink(controller: "payer", action: "restore", params: [id: payer.id])}"
+                               class="btn btn-default">Restaurar Pagador</a>
+                        </g:if>
+                        <g:else>
+                            <a href="${createLink(controller: "payer", action: "edit", params: [id: payer.id])}"
+                               class="btn btn-default">Editar Pagador</a>
+                            <a href="${createLink(controller: "payer", action: "delete", params: [id: payer.id])}"
+                               class="btn btn-default">Deletar Pagador</a>
+                        </g:else>
                     </div>
                 </section>
             </div>


### PR DESCRIPTION
Agora é possível acessar duas listas, uma para pagadores ativos e outra para não ativos, caso desejar tornar um pagador deletado ativo novamente foi acresentado nos detalhes um botão para restaura-lo, assim ele volta para lista de pagadores ativos, possibilitando editar seus dados ou torna-lo deletado novamente.

![restore](https://github.com/AlexandraPassos/CoinCollector/assets/130088877/2ecba19d-cea5-487c-937d-3ef88f5883e3)
